### PR TITLE
Add penaltyGapExtend and gapAlignmentSide parameters to pathogen.json

### DIFF
--- a/dataset/pathogen.json
+++ b/dataset/pathogen.json
@@ -15,6 +15,7 @@
     "reference accession": "< ref accession number of your virus >"
   },
   "alignmentParams": {
+        "penaltyGapExtend": 3,
         "penaltyGapOpen": 13,
         "penaltyGapOpenInFrame": 18,
         "penaltyGapOpenOutOfFrame": 23,

--- a/dataset/pathogen.json
+++ b/dataset/pathogen.json
@@ -24,6 +24,7 @@
         "minMatchLength": 30,
         "allowedMismatches": 15,
         "minLength": 100,
+        "gapAlignmentSide": "right",
         "minSeedCover": 0.30
     },
   "defaultCds": "VP1",


### PR DESCRIPTION
Adding penaltyGapExtend and gapAlignmentSide parameters to alignmentParams (pathogen.json), as it's required for running the snakemake (rule align).